### PR TITLE
Add link to PDB70 2020-05-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ For genetics:
 For templates:
 
 *   PDB: (downloaded 2020-05-14)
-*   PDB70: (downloaded 2020-05-13)
+*   PDB70: [2020-05-13](http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/old-releases/pdb70_from_mmcif_200513.tar.gz)
 
 An alternative for templates is to use the latest PDB and PDB70, but pass the
 flag `--max_template_date=2020-05-14`, which restricts templates only to


### PR DESCRIPTION
I copied the PDB70 from March 2020 of our tape archive system and made it available again on the download server.