### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/alphafold/common/protein.py
+++ b/alphafold/common/protein.py
@@ -196,7 +196,7 @@ def ideal_atom_mask(prot: Protein) -> np.ndarray:
 
   `Protein.atom_mask` typically is defined according to the atoms that are
   reported in the PDB. This function computes a mask according to heavy atoms
-  that should be present in the given seqence of amino acids.
+  that should be present in the given sequence of amino acids.
 
   Args:
     prot: `Protein` whose fields are `numpy.ndarray` objects.

--- a/alphafold/data/templates.py
+++ b/alphafold/data/templates.py
@@ -929,7 +929,7 @@ class TemplateHitFeaturizer:
         errors.append(result.error)
 
       # There could be an error even if there are some results, e.g. thrown by
-      # other unparseable chains in the same mmCIF file.
+      # other unparsable chains in the same mmCIF file.
       if result.warning:
         warnings.append(result.warning)
 

--- a/alphafold/model/all_atom.py
+++ b/alphafold/model/all_atom.py
@@ -582,7 +582,7 @@ def extreme_ca_ca_distance_violations(
     ) -> jnp.ndarray:
   """Counts residues whose Ca is a large distance from its neighbor.
 
-  Measures the fraction of CA-CA pairs between consectutive amino acids that
+  Measures the fraction of CA-CA pairs between consecutive amino acids that
   are more than 'max_angstrom_tolerance' apart.
 
   Args:

--- a/alphafold/model/tf/protein_features.py
+++ b/alphafold/model/tf/protein_features.py
@@ -95,7 +95,7 @@ def shape(feature_name: str,
 
   Args:
     feature_name: String identifier for the feature. If the feature name ends
-      with "_unnormalized", theis suffix is stripped off.
+      with "_unnormalized", this suffix is stripped off.
     num_residues: The number of residues in the current domain - some elements
       of the shape can be dynamic and will be replaced by this value.
     msa_length: The number of sequences in the multiple sequence alignment, some

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/opt/hhsuite .. \
     && ln -s /opt/hhsuite/bin/* /usr/bin \
     && rm -rf /tmp/hh-suite
 
-# Install Miniconda package manger.
+# Install Miniconda package manager.
 RUN wget -q -P /tmp \
   https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \


### PR DESCRIPTION
[`codespell --ignore-words-list="ba,conect,ser" -w`](https://github.com/codespell-project/codespell)