### PR TITLE
Update base image to cuda 11.2-cudnn8-runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG CUDA=11.0
-FROM nvidia/cuda:${CUDA}-base
+ARG CUDA_FULL=11.2.2
+FROM nvidia/cuda:${CUDA_FULL}-cudnn8-runtime-ubuntu20.04
 # FROM directive resets ARGS, so we specify again (the value is retained if
 # previously set).
-ARG CUDA
+ARG CUDA_FULL
+ARG CUDA=11.2
+# JAXLIB no longer built for all minor CUDA versions:
+# https://github.com/google/jax/blob/main/CHANGELOG.md#jaxlib-0166-may-11-2021
+ARG CUDA_JAXLIB=11.1
 
 # Use bash to support string substitution.
 SHELL ["/bin/bash", "-c"]
@@ -52,7 +56,7 @@ ENV PATH="/opt/conda/bin:$PATH"
 RUN conda update -qy conda \
     && conda install -y -c conda-forge \
       openmm=7.5.1 \
-      cudatoolkit==${CUDA}.3 \
+      cudatoolkit==${CUDA_FULL} \
       pdbfixer \
       pip
 
@@ -63,7 +67,7 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
 # Install pip packages.
 RUN pip3 install --upgrade pip \
     && pip3 install -r /app/alphafold/requirements.txt \
-    && pip3 install --upgrade jax jaxlib==0.1.69+cuda${CUDA/./} -f \
+    && pip3 install --upgrade jax jaxlib==0.1.69+cuda${CUDA_JAXLIB/./} -f \
       https://storage.googleapis.com/jax-releases/jax_releases.html
 
 # Apply OpenMM patch.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,9 +47,9 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/opt/hhsuite .. \
 
 # Install Miniconda package manger.
 RUN wget -q -P /tmp \
-  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \
-    && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
+  https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh \
+    && bash /tmp/Miniconda3-py38_4.9.2-Linux-x86_64.sh -b -p /opt/conda \
+    && rm /tmp/Miniconda3-py38_4.9.2-Linux-x86_64.sh
 
 # Install conda packages.
 ENV PATH="/opt/conda/bin:$PATH"


### PR DESCRIPTION
This brings in:
cuda 11.2
cudnn 8.1
cusolver 11.2

This brings in missing libraries needed by AF and aligns versions with TF 2.5 requirements:
https://www.tensorflow.org/install/source#gpu

I believe this:
Closes #11 
Closes #26