### PR TITLE
have the version of mgnify in run_docker.py match what is in download…

### DIFF
--- a/docker/run_docker.py
+++ b/docker/run_docker.py
@@ -57,7 +57,7 @@ uniref90_database_path = os.path.join(
 
 # Path to the MGnify database for use by JackHMMER.
 mgnify_database_path = os.path.join(
-    DOWNLOAD_DIR, 'mgnify', 'mgy_clusters_2018_08.fa')
+    DOWNLOAD_DIR, 'mgnify', 'mgy_clusters_2018_12.fa')
 
 # Path to the BFD database for use by HHblits.
 bfd_database_path = os.path.join(


### PR DESCRIPTION
…_mgnify.sh

line 36 of scripts/download_mgnify.sh hardcodes in the version `mgy_clusters_2018_12` as what is downloaded. run_docker currently looks for `mgy_clusters_2018_08` and subsequently fails.