### PR TITLE
Look for data file relative to current module

### DIFF
--- a/alphafold/common/residue_constants.py
+++ b/alphafold/common/residue_constants.py
@@ -16,6 +16,7 @@
 
 import collections
 import functools
+import os
 from typing import List, Mapping, Tuple
 
 import numpy as np
@@ -402,8 +403,9 @@ def load_stereo_chemical_props() -> Tuple[Mapping[str, List[Bond]],
     residue_virtual_bonds: dict that maps resname --> list of Bond tuples
     residue_bond_angles: dict that maps resname --> list of BondAngle tuples
   """
-  stereo_chemical_props_path = (
-      'alphafold/common/stereo_chemical_props.txt')
+  stereo_chemical_props_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'stereo_chemical_props.txt'
+  )
   with open(stereo_chemical_props_path, 'rt') as f:
     stereo_chemical_props = f.read()
   lines_iter = iter(stereo_chemical_props.splitlines())


### PR DESCRIPTION
Look for `stereo_chemical_props.txt` relative to the current module, rather than relative to the current working directory. This enables AlphaFold to be run in a working directory other than the sources directory.