### PR TITLE
Flag for output directory, write to current working directory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,11 @@ with 12 vCPUs, 85 GB of RAM, a 100 GB boot disk, the databases on an additional
 
 ### AlphaFold output
 
-The outputs will be in a subfolder of `output_dir` in `run_docker.py`. They
-include the computed MSAs, unrelaxed structures, relaxed structures, ranked
-structures, raw model outputs, prediction metadata, and section timings. The
-`output_dir` directory will have the following structure:
+The outputs will be in a subfolder of the `--output_dir` argument to
+`run_docker.py` (current working directory by default). They include the
+computed MSAs, unrelaxed structures, relaxed structures, ranked structures, raw
+model outputs, prediction metadata, and section timings. The `output_dir`
+directory will have the following structure:
 
 ```
 <target_name>/

--- a/docker/run_docker.py
+++ b/docker/run_docker.py
@@ -15,6 +15,7 @@
 """Docker launch script for Alphafold docker image."""
 
 import os
+from pathlib import Path
 import signal
 from typing import Tuple
 
@@ -32,9 +33,6 @@ DOWNLOAD_DIR = 'SET ME'
 
 # Name of the AlphaFold Docker image.
 docker_image_name = 'alphafold'
-
-# Path to a directory that will store the results.
-output_dir = '/tmp/alphafold'
 
 # Names of models to use.
 model_names = [
@@ -92,6 +90,7 @@ flags.DEFINE_list('fasta_paths', None, 'Paths to FASTA files, each containing '
                   'All FASTA paths must have a unique basename as the '
                   'basename is used to name the output directories for '
                   'each prediction.')
+flags.DEFINE_string('output_dir', os.getcwd(), 'Output directory')
 flags.DEFINE_string('max_template_date', None, 'Maximum template release date '
                     'to consider (ISO-8601 format - i.e. YYYY-MM-DD). '
                     'Important if folding historical test sets.')
@@ -135,6 +134,12 @@ def main(argv):
     mounts.append(mount)
     target_fasta_paths.append(target_path)
   command_args.append(f'--fasta_paths={",".join(target_fasta_paths)}')
+
+  # Set output directory and create if necessary
+  if FLAGS.output_dir is not None:
+    output_dir_path = Path(FLAGS.output_dir)
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+    output_dir = str(output_dir_path.resolve())
 
   database_paths = [
       ('uniref90_database_path', uniref90_database_path),


### PR DESCRIPTION
Instead of hardcoding a directory in the docker_run.py script, this MR adds the possiblity to set the ouput directory via an `--output_dir` flag.

If this flag is not set, the current working directory will be used.

If the directory does not exist, it will be created.