### PR TITLE
run_docker.py: Run as non-root user by default, allow setting the user via flag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,9 @@ RUN pip3 install --upgrade pip \
 WORKDIR /opt/conda/lib/python3.7/site-packages
 RUN patch -p0 < /app/alphafold/docker/openmm.patch
 
+# add SETUID bit to ldconfig binary so that non-root users can run it
+RUN chmod u+s /sbin/ldconfig.real
+
 # We need to run `ldconfig` first to ensure GPUs are visible, due to some quirk
 # with Debian. See https://github.com/NVIDIA/nvidia-docker/issues/1399 for
 # details.

--- a/docker/run_docker.py
+++ b/docker/run_docker.py
@@ -106,6 +106,10 @@ flags.DEFINE_boolean('benchmark', False, 'Run multiple JAX model evaluations '
                      'to obtain a timing that excludes the compilation time, '
                      'which should be more indicative of the time required for '
                      'inferencing many proteins.')
+flags.DEFINE_string('docker_user', f"{os.geteuid()}:{os.getegid()}", 'Numerical UNIX user ID with '
+                    'which to run docker container. '
+                    'The output directories will be owned by this user. '
+                    'By default, this is your current user.')
 
 FLAGS = flags.FLAGS
 
@@ -177,6 +181,7 @@ def main(argv):
       remove=True,
       detach=True,
       mounts=mounts,
+      user=FLAGS.docker_user,
       environment={
           'NVIDIA_VISIBLE_DEVICES': FLAGS.gpu_devices,
           # The following flags allow us to make predictions on proteins that


### PR DESCRIPTION
Currently, the whole process runs as root and output directories are all created with root:root ownership.

This patch allows to run the processes inside docker container as non-root user, so that any files produced will be owned by a user that can be specified.

By default, the process is run with the UID and GID of the current user.