### PR TITLE
Moved hard-coded /tmp TMPDIR to Dockerfile.

### DIFF
--- a/alphafold/data/tools/hhblits.py
+++ b/alphafold/data/tools/hhblits.py
@@ -96,7 +96,7 @@ class HHBlits:
 
   def query(self, input_fasta_path: str) -> Mapping[str, Any]:
     """Queries the database using HHblits."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager() as query_tmp_dir:
       a3m_path = os.path.join(query_tmp_dir, 'output.a3m')
 
       db_cmd = []

--- a/alphafold/data/tools/hhsearch.py
+++ b/alphafold/data/tools/hhsearch.py
@@ -57,7 +57,7 @@ class HHSearch:
 
   def query(self, a3m: str) -> str:
     """Queries the database using HHsearch using a given a3m."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager() as query_tmp_dir:
       input_path = os.path.join(query_tmp_dir, 'query.a3m')
       hhr_path = os.path.join(query_tmp_dir, 'output.hhr')
       with open(input_path, 'w') as f:

--- a/alphafold/data/tools/hmmbuild.py
+++ b/alphafold/data/tools/hmmbuild.py
@@ -98,7 +98,7 @@ class Hmmbuild(object):
       raise ValueError(f'Invalid model_construction {model_construction} - only'
                        'hand and fast supported.')
 
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager() as query_tmp_dir:
       input_query = os.path.join(query_tmp_dir, 'query.msa')
       output_hmm_path = os.path.join(query_tmp_dir, 'output.hmm')
 

--- a/alphafold/data/tools/hmmsearch.py
+++ b/alphafold/data/tools/hmmsearch.py
@@ -51,7 +51,7 @@ class Hmmsearch(object):
 
   def query(self, hmm: str) -> str:
     """Queries the database using hmmsearch using a given hmm."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager() as query_tmp_dir:
       hmm_input_path = os.path.join(query_tmp_dir, 'query.hmm')
       a3m_out_path = os.path.join(query_tmp_dir, 'output.a3m')
       with open(hmm_input_path, 'w') as f:

--- a/alphafold/data/tools/jackhmmer.py
+++ b/alphafold/data/tools/jackhmmer.py
@@ -89,7 +89,7 @@ class Jackhmmer:
   def _query_chunk(self, input_fasta_path: str, database_path: str
                    ) -> Mapping[str, Any]:
     """Queries the database chunk using Jackhmmer."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager() as query_tmp_dir:
       sto_path = os.path.join(query_tmp_dir, 'output.sto')
 
       # The F1/F2/F3 are the expected proportion to pass each of the filtering

--- a/alphafold/data/tools/kalign.py
+++ b/alphafold/data/tools/kalign.py
@@ -70,7 +70,7 @@ class Kalign:
         raise ValueError('Kalign requires all sequences to be at least 6 '
                          'residues long. Got %s (%d residues).' % (s, len(s)))
 
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager() as query_tmp_dir:
       input_fasta_path = os.path.join(query_tmp_dir, 'input.fasta')
       output_a3m_path = os.path.join(query_tmp_dir, 'output.a3m')
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,4 +82,5 @@ RUN echo $'#!/bin/bash\n\
 ldconfig\n\
 python /app/alphafold/run_alphafold.py "$@"' > /app/run_alphafold.sh \
   && chmod +x /app/run_alphafold.sh
+ENV TMPDIR="/tmp"
 ENTRYPOINT ["/app/run_alphafold.sh"]


### PR DESCRIPTION
Fixes #138. See that issue for extended background and rationale.

Previously, use of `/tmp` as the temporary directory was hard-coded into every data pipeline tool run.

When running Alphafold outside of Docker (e.g. on a cluster where `/tmp` may be a size-limited directory and the environment variable `TMPDIR` is set), this hard-coding may cause the `/tmp` directory to run out of space.

By removing these hard-coded paths and relying on the `mkdtemp` behavior (which checks the environment variables `TMPDIR` among others) and setting `TMPDIR` in the Dockerfile, we can make this easier to run both inside and outside of Docker. Explicitly, the `tempfile` package [checks the following locations](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir):

> 1. The directory named by the TMPDIR environment variable.
> 2. The directory named by the TEMP environment variable.
> 3. The directory named by the TMP environment variable.
> 4. A platform-specific location:
>    On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order.
>    On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.
> 5. As a last resort, the current working directory.

To ensure that we are not relying on search behavior, I have explicitly set the environment variable `TMPDIR` to `/tmp`, guaranteeing that the behavior remains the same when run inside Docker, while ensuring that when run outside of Docker, users can freely set a better temporary directory location by setting these environment variables.