### PR TITLE
do not use hardcoded /tmp, respect TMPDIR

### DIFF
--- a/alphafold/data/tools/hhblits.py
+++ b/alphafold/data/tools/hhblits.py
@@ -96,7 +96,7 @@ class HHBlits:
 
   def query(self, input_fasta_path: str) -> Mapping[str, Any]:
     """Queries the database using HHblits."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TEMPDIR) as query_tmp_dir:
       a3m_path = os.path.join(query_tmp_dir, 'output.a3m')
 
       db_cmd = []

--- a/alphafold/data/tools/hhblits.py
+++ b/alphafold/data/tools/hhblits.py
@@ -96,7 +96,7 @@ class HHBlits:
 
   def query(self, input_fasta_path: str) -> Mapping[str, Any]:
     """Queries the database using HHblits."""
-    with utils.tmpdir_manager(base_dir=utils.TEMPDIR) as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TMPDIR) as query_tmp_dir:
       a3m_path = os.path.join(query_tmp_dir, 'output.a3m')
 
       db_cmd = []

--- a/alphafold/data/tools/hhsearch.py
+++ b/alphafold/data/tools/hhsearch.py
@@ -57,7 +57,7 @@ class HHSearch:
 
   def query(self, a3m: str) -> str:
     """Queries the database using HHsearch using a given a3m."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TMPDIR) as query_tmp_dir:
       input_path = os.path.join(query_tmp_dir, 'query.a3m')
       hhr_path = os.path.join(query_tmp_dir, 'output.hhr')
       with open(input_path, 'w') as f:

--- a/alphafold/data/tools/hmmbuild.py
+++ b/alphafold/data/tools/hmmbuild.py
@@ -98,7 +98,7 @@ class Hmmbuild(object):
       raise ValueError(f'Invalid model_construction {model_construction} - only'
                        'hand and fast supported.')
 
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TMPDIR) as query_tmp_dir:
       input_query = os.path.join(query_tmp_dir, 'query.msa')
       output_hmm_path = os.path.join(query_tmp_dir, 'output.hmm')
 

--- a/alphafold/data/tools/hmmsearch.py
+++ b/alphafold/data/tools/hmmsearch.py
@@ -51,7 +51,7 @@ class Hmmsearch(object):
 
   def query(self, hmm: str) -> str:
     """Queries the database using hmmsearch using a given hmm."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TMPDIR) as query_tmp_dir:
       hmm_input_path = os.path.join(query_tmp_dir, 'query.hmm')
       a3m_out_path = os.path.join(query_tmp_dir, 'output.a3m')
       with open(hmm_input_path, 'w') as f:

--- a/alphafold/data/tools/jackhmmer.py
+++ b/alphafold/data/tools/jackhmmer.py
@@ -89,7 +89,7 @@ class Jackhmmer:
   def _query_chunk(self, input_fasta_path: str, database_path: str
                    ) -> Mapping[str, Any]:
     """Queries the database chunk using Jackhmmer."""
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TMPDIR) as query_tmp_dir:
       sto_path = os.path.join(query_tmp_dir, 'output.sto')
 
       # The F1/F2/F3 are the expected proportion to pass each of the filtering
@@ -164,7 +164,7 @@ class Jackhmmer:
 
     db_basename = os.path.basename(self.database_path)
     db_remote_chunk = lambda db_idx: f'{self.database_path}.{db_idx}'
-    db_local_chunk = lambda db_idx: f'/tmp/ramdisk/{db_basename}.{db_idx}'
+    db_local_chunk = lambda db_idx: os.path.join(utils.TMPDIR, 'ramdisk', f'{db_basename}.{db_idx}')
 
     # Remove existing files to prevent OOM
     for f in glob.glob(db_local_chunk('[0-9]*')):

--- a/alphafold/data/tools/kalign.py
+++ b/alphafold/data/tools/kalign.py
@@ -70,7 +70,7 @@ class Kalign:
         raise ValueError('Kalign requires all sequences to be at least 6 '
                          'residues long. Got %s (%d residues).' % (s, len(s)))
 
-    with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
+    with utils.tmpdir_manager(base_dir=utils.TMPDIR) as query_tmp_dir:
       input_fasta_path = os.path.join(query_tmp_dir, 'input.fasta')
       output_a3m_path = os.path.join(query_tmp_dir, 'output.a3m')
 

--- a/alphafold/data/tools/utils.py
+++ b/alphafold/data/tools/utils.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from absl import logging
 
+TMPDIR = tempfile.gettempdir()
 
 @contextlib.contextmanager
 def tmpdir_manager(base_dir: Optional[str] = None):

--- a/alphafold/relax/amber_minimize.py
+++ b/alphafold/relax/amber_minimize.py
@@ -15,6 +15,7 @@
 """Restrained Amber Minimization of a structure."""
 
 import io
+import os
 import time
 from typing import Collection, Optional, Sequence
 
@@ -35,6 +36,8 @@ from simtk.openmm.app.internal.pdbstructure import PdbStructure
 ENERGY = unit.kilocalories_per_mole
 LENGTH = unit.angstroms
 
+#--- allow to run ambermininmize on selected platform CPU//GPU
+OPENMM_PLATFORM=os.environ.get('OPENMM_RELAX', 'CPU')
 
 def will_restrain(atom: openmm_app.Atom, rset: str) -> bool:
   """Returns True if the atom will be restrained by the given restraint set."""
@@ -90,7 +93,7 @@ def _openmm_minimize(
     _add_restraints(system, pdb, stiffness, restraint_set, exclude_residues)
 
   integrator = openmm.LangevinIntegrator(0, 0.01, 0.0)
-  platform = openmm.Platform.getPlatformByName("CPU")
+  platform = openmm.Platform.getPlatformByName(OPENMM_PLATFORM)
   simulation = openmm_app.Simulation(
       pdb.topology, system, integrator, platform)
   simulation.context.setPositions(pdb.positions)
@@ -530,7 +533,7 @@ def get_initial_energies(pdb_strs: Sequence[str],
   simulation = openmm_app.Simulation(openmm_pdbs[0].topology,
                                      system,
                                      openmm.LangevinIntegrator(0, 0.01, 0.0),
-                                     openmm.Platform.getPlatformByName("CPU"))
+                                     openmm.Platform.getPlatformByName(OPENMM_PLATFORM))
   energies = []
   for pdb in openmm_pdbs:
     try:


### PR DESCRIPTION
Hello.

you may want to respect TMPDIR environnement variable instead of hard-coding `/tmp` paths for temporary files.
on some clusters TMPDIR points to some scratch location and /tmp is too small to hold temporary files

regards

Eric