### PR TITLE
Rewrites to read jackhmmer output line-by-line

### DIFF
--- a/alphafold/data/pipeline.py
+++ b/alphafold/data/pipeline.py
@@ -131,21 +131,18 @@ class DataPipeline:
     num_res = len(input_sequence)
 
     jackhmmer_uniref90_result = self.jackhmmer_uniref90_runner.query(
-        input_fasta_path)[0]
+      input_fasta_path,
+      sto_path=os.path.join(msa_output_dir, 'uniref90_hits.sto'),
+      max_hits=self.uniref_max_hits,
+      a3m_needed=True)[0]
     jackhmmer_mgnify_result = self.jackhmmer_mgnify_runner.query(
-        input_fasta_path)[0]
+      input_fasta_path,
+      sto_path=os.path.join(msa_output_dir, 'mgnify_hits.sto'),
+      max_hits=self.mgnify_max_hits,
+      a3m_needed=False)[0]
 
-    uniref90_msa_as_a3m = parsers.convert_stockholm_to_a3m(
-        jackhmmer_uniref90_result['sto'], max_sequences=self.uniref_max_hits)
+    uniref90_msa_as_a3m = jackhmmer_uniref90_result['a3m']
     hhsearch_result = self.hhsearch_pdb70_runner.query(uniref90_msa_as_a3m)
-
-    uniref90_out_path = os.path.join(msa_output_dir, 'uniref90_hits.sto')
-    with open(uniref90_out_path, 'w') as f:
-      f.write(jackhmmer_uniref90_result['sto'])
-
-    mgnify_out_path = os.path.join(msa_output_dir, 'mgnify_hits.sto')
-    with open(mgnify_out_path, 'w') as f:
-      f.write(jackhmmer_mgnify_result['sto'])
 
     pdb70_out_path = os.path.join(msa_output_dir, 'pdb70_hits.hhr')
     with open(pdb70_out_path, 'w') as f:
@@ -156,8 +153,6 @@ class DataPipeline:
     mgnify_msa, mgnify_deletion_matrix, _ = parsers.parse_stockholm(
         jackhmmer_mgnify_result['sto'])
     hhsearch_hits = parsers.parse_hhr(hhsearch_result)
-    mgnify_msa = mgnify_msa[:self.mgnify_max_hits]
-    mgnify_deletion_matrix = mgnify_deletion_matrix[:self.mgnify_max_hits]
 
     if self._use_small_bfd:
       jackhmmer_small_bfd_result = self.jackhmmer_small_bfd_runner.query(

--- a/alphafold/data/tools/jackhmmer.py
+++ b/alphafold/data/tools/jackhmmer.py
@@ -24,6 +24,7 @@ from urllib import request
 from absl import logging
 
 from alphafold.data.tools import utils
+from alphafold.data import parsers
 # Internal import (7716).
 
 
@@ -86,12 +87,17 @@ class Jackhmmer:
     self.get_tblout = get_tblout
     self.streaming_callback = streaming_callback
 
-  def _query_chunk(self, input_fasta_path: str, database_path: str
+  def _query_chunk(self, input_fasta_path: str,
+                   database_path: str,
+                   sto_path: Optional[str] = None,
+                   max_hits: Optional[int] = None,
+                   a3m_needed: Optional[bool] = None
                    ) -> Mapping[str, Any]:
     """Queries the database chunk using Jackhmmer."""
     with utils.tmpdir_manager(base_dir='/tmp') as query_tmp_dir:
-      sto_path = os.path.join(query_tmp_dir, 'output.sto')
-
+      if not sto_path:
+        sto_path = os.path.join(query_tmp_dir, 'output.sto')
+        
       # The F1/F2/F3 are the expected proportion to pass each of the filtering
       # stages (which get progressively more expensive), reducing these
       # speeds up the pipeline at the expensive of sensitivity.  They are
@@ -145,11 +151,14 @@ class Jackhmmer:
         with open(tblout_path) as f:
           tbl = f.read()
 
-      with open(sto_path) as f:
-        sto = f.read()
+      if not a3m_needed:
+        sto, a3m = parsers.get_sto(sto_path, max_hits), None
+      else:
+        sto, a3m = parsers.get_sto_a3m(sto_path, max_hits)
 
     raw_output = dict(
         sto=sto,
+        a3m=a3m,
         tbl=tbl,
         stderr=stderr,
         n_iter=self.n_iter,
@@ -157,10 +166,13 @@ class Jackhmmer:
 
     return raw_output
 
-  def query(self, input_fasta_path: str) -> Sequence[Mapping[str, Any]]:
+  def query(self, input_fasta_path: str,
+            sto_path: Optional[str] = None,
+            max_hits: Optional[int] = None,
+            a3m_needed: Optional[bool] = None) -> Sequence[Mapping[str, Any]]:
     """Queries the database using Jackhmmer."""
     if self.num_streamed_chunks is None:
-      return [self._query_chunk(input_fasta_path, self.database_path)]
+      return [self._query_chunk(input_fasta_path, self.database_path, sto_path, max_hits, a3m_needed)]
 
     db_basename = os.path.basename(self.database_path)
     db_remote_chunk = lambda db_idx: f'{self.database_path}.{db_idx}'


### PR DESCRIPTION
jackhmmer searches may result in alignment file of size over 100GB in the case of highly conserved target proteins. The original AF2 code reads the whole file into memory, parses there, and applies the limit that may cause out of memory error.

Our modifications implement the line-by-line reading of jackhmmer ouput sto files thus decrease the size of required RAM for AF2 predictions of conserved proteins.