### PR TITLE
Changes to avoid reading the whole MSA files into the memory thus Memory Errors

### DIFF
--- a/alphafold/data/parsers.py
+++ b/alphafold/data/parsers.py
@@ -271,6 +271,28 @@ def _keep_line(line: str, seqnames: Set[str]) -> bool:
     return seqname in seqnames
 
 
+def get_stockholm_msa(msa_out_path: str, max_sequences: int) -> str:
+  """Reads alignment from an sto file and truncates it to max_hits"""
+  seqnames = set()
+  filtered_lines = []
+  with open(msa_out_path) as sto_fh:
+    for line in sto_fh:
+      if line.strip() and not line.startswith(('#', '//')):
+        # Ignore blank lines, markup and end symbols - remainder are alignment
+        # sequence parts.
+        seqname = line.partition(' ')[0]
+        seqnames.add(seqname)
+        if len(seqnames) >= max_sequences:
+          break
+
+    sto_fh.seek(0)
+    for line in sto_fh:
+      if _keep_line(line, seqnames):
+        filtered_lines.append(line)
+
+  return ''.join(filtered_lines)
+    
+
 def truncate_stockholm_msa(stockholm_msa: str, max_sequences: int) -> str:
   """Truncates a stockholm file to a maximum number of sequences."""
   seqnames = set()

--- a/alphafold/data/pipeline.py
+++ b/alphafold/data/pipeline.py
@@ -91,12 +91,11 @@ def make_msa_features(msas: Sequence[parsers.Msa]) -> FeatureDict:
 
 def run_msa_tool(msa_runner, input_fasta_path: str, msa_out_path: str,
                  msa_format: str, use_precomputed_msas: bool,
+                 max_hits: Optional[int] = None
                  ) -> Mapping[str, Any]:
   """Runs an MSA tool, checking if output already exists first."""
   if not use_precomputed_msas or not os.path.exists(msa_out_path):
-    result = msa_runner.query(input_fasta_path)[0]
-    with open(msa_out_path, 'w') as f:
-      f.write(result[msa_format])
+    result = msa_runner.query(input_fasta_path, msa_out_path, max_hits)[0]
   else:
     logging.warning('Reading MSA from file %s', msa_out_path)
     with open(msa_out_path, 'r') as f:
@@ -157,12 +156,12 @@ class DataPipeline:
 
     uniref90_out_path = os.path.join(msa_output_dir, 'uniref90_hits.sto')
     jackhmmer_uniref90_result = run_msa_tool(
-        self.jackhmmer_uniref90_runner, input_fasta_path, uniref90_out_path,
-        'sto', self.use_precomputed_msas)
+      self.jackhmmer_uniref90_runner, input_fasta_path, uniref90_out_path,
+      'sto', self.use_precomputed_msas, max_hits=self.uniref_max_hits)
     mgnify_out_path = os.path.join(msa_output_dir, 'mgnify_hits.sto')
     jackhmmer_mgnify_result = run_msa_tool(
-        self.jackhmmer_mgnify_runner, input_fasta_path, mgnify_out_path, 'sto',
-        self.use_precomputed_msas)
+      self.jackhmmer_mgnify_runner, input_fasta_path, mgnify_out_path, 'sto',
+      self.use_precomputed_msas, max_hits=self.mgnify_max_hits)
 
     msa_for_templates = jackhmmer_uniref90_result['sto']
     msa_for_templates = parsers.truncate_stockholm_msa(
@@ -187,9 +186,7 @@ class DataPipeline:
       f.write(pdb_templates_result)
 
     uniref90_msa = parsers.parse_stockholm(jackhmmer_uniref90_result['sto'])
-    uniref90_msa = uniref90_msa.truncate(max_seqs=self.uniref_max_hits)
     mgnify_msa = parsers.parse_stockholm(jackhmmer_mgnify_result['sto'])
-    mgnify_msa = mgnify_msa.truncate(max_seqs=self.mgnify_max_hits)
 
     pdb_template_hits = self.template_searcher.get_template_hits(
         output_string=pdb_templates_result, input_sequence=input_sequence)

--- a/alphafold/data/pipeline_multimer.py
+++ b/alphafold/data/pipeline_multimer.py
@@ -226,9 +226,9 @@ class DataPipeline:
     out_path = os.path.join(msa_output_dir, 'uniprot_hits.sto')
     result = pipeline.run_msa_tool(
         self._uniprot_msa_runner, input_fasta_path, out_path, 'sto',
-        self.use_precomputed_msas)
+        self.use_precomputed_msas, max_hits=self._max_uniprot_hits)
     msa = parsers.parse_stockholm(result['sto'])
-    msa = msa.truncate(max_seqs=self._max_uniprot_hits)
+
     all_seq_features = pipeline.make_msa_features([msa])
     valid_feats = msa_pairing.MSA_FEATURES + (
         'msa_uniprot_accession_identifiers',

--- a/alphafold/data/tools/hhblits.py
+++ b/alphafold/data/tools/hhblits.py
@@ -94,7 +94,9 @@ class HHBlits:
     self.p = p
     self.z = z
 
-  def query(self, input_fasta_path: str) -> List[Mapping[str, Any]]:
+  def query(self, input_fasta_path: str,
+            msa_out_path: Optional[str] = None,
+            max_hits_none: Optional[str] = None) -> List[Mapping[str, Any]]:
     """Queries the database using HHblits."""
     with utils.tmpdir_manager() as query_tmp_dir:
       a3m_path = os.path.join(query_tmp_dir, 'output.a3m')
@@ -152,4 +154,7 @@ class HHBlits:
         stderr=stderr,
         n_iter=self.n_iter,
         e_value=self.e_value)
+
+    with open(msa_out_path, 'w') as f:
+      f.write(raw_output['a3m'])
     return [raw_output]


### PR DESCRIPTION
Sequence searches may result in alignment file (over 100GB).
The original AF2 code reads the whole file into memory and parses there that may cause out of memory error.

Our modifications implement the line-by-line reading of MSA files thus decrease the required RAM size for AF2 predictions.
