### PR TITLE
Changing version dependency on jaxlib

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
 # Install pip packages.
 RUN pip3 install --upgrade pip \
     && pip3 install -r /app/alphafold/requirements.txt \
-    && pip3 install --upgrade jax jaxlib==0.1.69+cuda${CUDA/./} -f \
+    && pip3 install --upgrade jax jaxlib>=0.1.69+cuda${CUDA/./} -f \
       https://storage.googleapis.com/jax-releases/jax_releases.html
 
 # Apply OpenMM patch.


### PR DESCRIPTION
This is a trivial change to [Line 68](https://github.com/deepmind/alphafold/blob/be37a41d6f83e4145bd4912cbe8bf6a24af80c29/docker/Dockerfile#L68) of `docker/Dockerfile` that has the requirement for `jaxlib==1.6.9`.

A detailed description is provided in the associated issue.

Closes #298