### PR TITLE
Do not upgrade jax in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
 # Install pip packages.
 RUN pip3 install --upgrade pip \
     && pip3 install -r /app/alphafold/requirements.txt \
-    && pip3 install --upgrade jax jaxlib==0.1.69+cuda${CUDA/./} -f \
+    && pip3 install --upgrade jaxlib==0.1.69+cuda${CUDA/./} -f \
       https://storage.googleapis.com/jax-releases/jax_releases.html
 
 # Apply OpenMM patch.


### PR DESCRIPTION
The Dockerfile pins jaxlib and then upgrades jax to the newest version.  This leads to a jax version being installed that is incompatible with the pinned jaxlib version.  See #298 

So everyone is working with the same versions, jax should not be upgraded.   This change accomplishes this.

As DeepMind validates the newer jax/jaxlib versions give correct results, then newer versions of jax/jaxlib can be pinned.

Closes #298