### PR TITLE
Add command-line flag to control Amber relaxation

### DIFF
--- a/docker/run_docker.py
+++ b/docker/run_docker.py
@@ -74,6 +74,9 @@ flags.DEFINE_boolean(
     'use_precomputed_msas', False,
     'Whether to read MSAs that have been written to disk. WARNING: This will '
     'not check if the sequence, database or configuration have changed.')
+flags.DEFINE_boolean(
+    'use_amber_relaxation', True,
+    'Whether to run the relaxation step on the predicted models using Amber.')
 
 FLAGS = flags.FLAGS
 
@@ -191,6 +194,7 @@ def main(argv):
       f'--model_preset={FLAGS.model_preset}',
       f'--benchmark={FLAGS.benchmark}',
       f'--use_precomputed_msas={FLAGS.use_precomputed_msas}',
+      f'--use_amber_relaxation={FLAGS.use_amber_relaxation}',
       '--logtostderr',
   ])
 

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -116,6 +116,8 @@ flags.DEFINE_integer('random_seed', None, 'The random seed for the data '
 flags.DEFINE_boolean('use_precomputed_msas', False, 'Whether to read MSAs that '
                      'have been written to disk. WARNING: This will not check '
                      'if the sequence, database or configuration have changed.')
+flags.DEFINE_boolean('use_amber_relaxation', True, 'Whether to run the '
+                     'relaxation step on the predicted models using Amber.')
 
 FLAGS = flags.FLAGS
 
@@ -384,12 +386,14 @@ def main(argv):
   logging.info('Have %d models: %s', len(model_runners),
                list(model_runners.keys()))
 
-  amber_relaxer = relax.AmberRelaxation(
-      max_iterations=RELAX_MAX_ITERATIONS,
-      tolerance=RELAX_ENERGY_TOLERANCE,
-      stiffness=RELAX_STIFFNESS,
-      exclude_residues=RELAX_EXCLUDE_RESIDUES,
-      max_outer_iterations=RELAX_MAX_OUTER_ITERATIONS)
+  amber_relaxer = None
+  if FLAGS.use_amber_relaxation:
+    amber_relaxer = relax.AmberRelaxation(
+        max_iterations=RELAX_MAX_ITERATIONS,
+        tolerance=RELAX_ENERGY_TOLERANCE,
+        stiffness=RELAX_STIFFNESS,
+        exclude_residues=RELAX_EXCLUDE_RESIDUES,
+        max_outer_iterations=RELAX_MAX_OUTER_ITERATIONS)
 
   random_seed = FLAGS.random_seed
   if random_seed is None:


### PR DESCRIPTION
For some uses of the predicted models, the relaxation step using Amber is not necessary. This pull request adds the `--use_amber_relaxation` flag to the `run_alphafold.py` and `run_docker.py` files to control whether or not the relaxation step is run. The default is True and preserves the existing behavior.

Co-authored-by: @terwill