### PR TITLE
Allowing cpus to be set annd used in run_alphafold.py

### DIFF
--- a/alphafold/data/pipeline.py
+++ b/alphafold/data/pipeline.py
@@ -129,11 +129,12 @@ class DataPipeline:
                use_small_bfd: bool,
                mgnify_max_hits: int = 501,
                uniref_max_hits: int = 10000,
-               use_precomputed_msas: bool = False):
+               use_precomputed_msas: bool = False, n_cpu: int = 4):
     """Initializes the data pipeline."""
+    self.n_cpu = n_cpu
     self._use_small_bfd = use_small_bfd
     self.jackhmmer_uniref90_runner = jackhmmer.Jackhmmer(
-        binary_path=jackhmmer_binary_path,
+        binary_path=jackhmmer_binary_path, n_cpu=self.n_cpu,
         database_path=uniref90_database_path)
     if use_small_bfd:
       self.jackhmmer_small_bfd_runner = jackhmmer.Jackhmmer(
@@ -141,7 +142,7 @@ class DataPipeline:
           database_path=small_bfd_database_path)
     else:
       self.hhblits_bfd_uniclust_runner = hhblits.HHBlits(
-          binary_path=hhblits_binary_path,
+          binary_path=hhblits_binary_path, n_cpu=self.n_cpu,
           databases=[bfd_database_path, uniclust30_database_path])
     self.jackhmmer_mgnify_runner = jackhmmer.Jackhmmer(
         binary_path=jackhmmer_binary_path,

--- a/alphafold/data/pipeline_multimer.py
+++ b/alphafold/data/pipeline_multimer.py
@@ -175,7 +175,8 @@ class DataPipeline:
                jackhmmer_binary_path: str,
                uniprot_database_path: str,
                max_uniprot_hits: int = 50000,
-               use_precomputed_msas: bool = False):
+               use_precomputed_msas: bool = False,
+               n_cpu: int = 8):
     """Initializes the data pipeline.
 
     Args:
@@ -187,9 +188,10 @@ class DataPipeline:
       max_uniprot_hits: The maximum number of hits to return from uniprot.
       use_precomputed_msas: Whether to use pre-existing MSAs; see run_alphafold.
     """
+    self.n_cpu = n_cpu
     self._monomer_data_pipeline = monomer_data_pipeline
     self._uniprot_msa_runner = jackhmmer.Jackhmmer(
-        binary_path=jackhmmer_binary_path,
+        binary_path=jackhmmer_binary_path, n_cpu=self.n_cpu,
         database_path=uniprot_database_path)
     self._max_uniprot_hits = max_uniprot_hits
     self.use_precomputed_msas = use_precomputed_msas

--- a/alphafold/data/tools/hhsearch.py
+++ b/alphafold/data/tools/hhsearch.py
@@ -33,7 +33,8 @@ class HHSearch:
                *,
                binary_path: str,
                databases: Sequence[str],
-               maxseq: int = 1_000_000):
+               maxseq: int = 1_000_000,
+               cpus: int = 8):
     """Initializes the Python HHsearch wrapper.
 
     Args:
@@ -47,6 +48,7 @@ class HHSearch:
     Raises:
       RuntimeError: If HHsearch binary not found within the path.
     """
+    self.cpus = cpus
     self.binary_path = binary_path
     self.databases = databases
     self.maxseq = maxseq
@@ -79,7 +81,8 @@ class HHSearch:
       cmd = [self.binary_path,
              '-i', input_path,
              '-o', hhr_path,
-             '-maxseq', str(self.maxseq)
+             '-maxseq', str(self.maxseq),
+             '-cpu', str(self.cpus)
              ] + db_cmd
 
       logging.info('Launching subprocess "%s"', ' '.join(cmd))

--- a/alphafold/data/tools/hmmsearch.py
+++ b/alphafold/data/tools/hmmsearch.py
@@ -33,6 +33,7 @@ class Hmmsearch(object):
                binary_path: str,
                hmmbuild_binary_path: str,
                database_path: str,
+               cpus: int = 8,
                flags: Optional[Sequence[str]] = None):
     """Initializes the Python hmmsearch wrapper.
 
@@ -46,6 +47,7 @@ class Hmmsearch(object):
     Raises:
       RuntimeError: If hmmsearch binary not found within the path.
     """
+    self.cpus = cpus
     self.binary_path = binary_path
     self.hmmbuild_runner = hmmbuild.Hmmbuild(binary_path=hmmbuild_binary_path)
     self.database_path = database_path
@@ -89,7 +91,7 @@ class Hmmsearch(object):
       cmd = [
           self.binary_path,
           '--noali',  # Don't include the alignment in stdout.
-          '--cpu', '8'
+          '--cpu', str(self.cpus)
       ]
       # If adding flags, we have to do so before the output and input:
       if self.flags:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ ml-collections==0.1.0
 numpy==1.19.5
 pandas==1.3.4
 scipy==1.7.0
-tensorflow-cpu==2.5.0
+tensorflow==2.5.0 # The generic version work with both gpu and cpu

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -125,10 +125,11 @@ flags.DEFINE_boolean('run_relax', True, 'Whether to run the final relaxation '
                      'result in predictions with distracting stereochemical '
                      'violations but might help in case you are having issues '
                      'with the relaxation stage.')
-flags.DEFINE_boolean('use_gpu_relax', None, 'Whether to relax on GPU. '
+flags.DEFINE_boolean('use_gpu_relax', False, 'Whether to relax on GPU. '
                      'Relax on GPU can be much faster than CPU, so it is '
                      'recommended to enable if possible. GPUs must be available'
                      ' if this setting is enabled.')
+flags.DEFINE_boolean('cpus', 8, 'Number of cpus/threads to use')
 
 FLAGS = flags.FLAGS
 
@@ -339,7 +340,9 @@ def main(argv):
     template_searcher = hmmsearch.Hmmsearch(
         binary_path=FLAGS.hmmsearch_binary_path,
         hmmbuild_binary_path=FLAGS.hmmbuild_binary_path,
-        database_path=FLAGS.pdb_seqres_database_path)
+        database_path=FLAGS.pdb_seqres_database_path,
+        cpus=FLAGS.cpus
+    )
     template_featurizer = templates.HmmsearchHitFeaturizer(
         mmcif_dir=FLAGS.template_mmcif_dir,
         max_template_date=FLAGS.max_template_date,
@@ -350,6 +353,7 @@ def main(argv):
   else:
     template_searcher = hhsearch.HHSearch(
         binary_path=FLAGS.hhsearch_binary_path,
+        cpus=FLAGS.cpus,
         databases=[FLAGS.pdb70_database_path])
     template_featurizer = templates.HhsearchHitFeaturizer(
         mmcif_dir=FLAGS.template_mmcif_dir,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     license='Apache License, Version 2.0',
     url='https://github.com/deepmind/alphafold',
     packages=find_packages(),
+    scripts=['run_alphafold.py', 'run_alphafold_test.py'],
     install_requires=[
         'absl-py',
         'biopython',


### PR DESCRIPTION
Change requirements so that TF is both cpu and gpu enabled
Set a default for use_gpu_relax that would not fail in the run (False in this case)
Adding cpu in hhsearch, hhblits, jackhmmer and hmmersearch wrappers as well as in the main call, add n_cpu to pipeline.DataPipeline and pipeline_multimer and adjust jackhmmer and hhblits to accept said attribute