### PR TITLE
Parallel execution of MSA tools

### DIFF
--- a/alphafold/data/pipeline.py
+++ b/alphafold/data/pipeline.py
@@ -27,6 +27,8 @@ from alphafold.data.tools import hmmsearch
 from alphafold.data.tools import jackhmmer
 import numpy as np
 
+import concurrent.futures
+
 # Internal import (7716).
 
 FeatureDict = MutableMapping[str, np.ndarray]
@@ -124,7 +126,8 @@ class DataPipeline:
                use_small_bfd: bool,
                mgnify_max_hits: int = 501,
                uniref_max_hits: int = 10000,
-               use_precomputed_msas: bool = False):
+               use_precomputed_msas: bool = False,
+               n_parallel_msa: int = 1):
     """Initializes the data pipeline."""
     self._use_small_bfd = use_small_bfd
     self.jackhmmer_uniref90_runner = jackhmmer.Jackhmmer(
@@ -146,35 +149,13 @@ class DataPipeline:
     self.mgnify_max_hits = mgnify_max_hits
     self.uniref_max_hits = uniref_max_hits
     self.use_precomputed_msas = use_precomputed_msas
+    self.n_parallel_msa = n_parallel_msa
 
-  def process(self, input_fasta_path: str, msa_output_dir: str) -> FeatureDict:
-    """Runs alignment tools on the input sequence and creates features."""
-    with open(input_fasta_path) as f:
-      input_fasta_str = f.read()
-    input_seqs, input_descs = parsers.parse_fasta(input_fasta_str)
-    if len(input_seqs) != 1:
-      raise ValueError(
-          f'More than one input sequence found in {input_fasta_path}.')
-    input_sequence = input_seqs[0]
-    input_description = input_descs[0]
-    num_res = len(input_sequence)
-
+  def jackhmmer_uniref90_and_pdb_templates_caller(self, input_fasta_path, msa_output_dir, input_sequence):
     uniref90_out_path = os.path.join(msa_output_dir, 'uniref90_hits.sto')
     jackhmmer_uniref90_result = run_msa_tool(
-        msa_runner=self.jackhmmer_uniref90_runner,
-        input_fasta_path=input_fasta_path,
-        msa_out_path=uniref90_out_path,
-        msa_format='sto',
-        use_precomputed_msas=self.use_precomputed_msas,
-        max_sto_sequences=self.uniref_max_hits)
-    mgnify_out_path = os.path.join(msa_output_dir, 'mgnify_hits.sto')
-    jackhmmer_mgnify_result = run_msa_tool(
-        msa_runner=self.jackhmmer_mgnify_runner,
-        input_fasta_path=input_fasta_path,
-        msa_out_path=mgnify_out_path,
-        msa_format='sto',
-        use_precomputed_msas=self.use_precomputed_msas,
-        max_sto_sequences=self.mgnify_max_hits)
+        self.jackhmmer_uniref90_runner, input_fasta_path, uniref90_out_path,
+        'sto', self.use_precomputed_msas)
 
     msa_for_templates = jackhmmer_uniref90_result['sto']
     msa_for_templates = parsers.deduplicate_stockholm_msa(msa_for_templates)
@@ -196,29 +177,73 @@ class DataPipeline:
       f.write(pdb_templates_result)
 
     uniref90_msa = parsers.parse_stockholm(jackhmmer_uniref90_result['sto'])
-    mgnify_msa = parsers.parse_stockholm(jackhmmer_mgnify_result['sto'])
+    uniref90_msa = uniref90_msa.truncate(max_seqs=self.uniref_max_hits)
 
     pdb_template_hits = self.template_searcher.get_template_hits(
         output_string=pdb_templates_result, input_sequence=input_sequence)
+    return uniref90_msa, pdb_template_hits
 
+  def jackhmmer_mgnify_caller(self, input_fasta_path, msa_output_dir):
+    mgnify_out_path = os.path.join(msa_output_dir, 'mgnify_hits.sto')
+    jackhmmer_mgnify_result = run_msa_tool(
+        self.jackhmmer_mgnify_runner, input_fasta_path, mgnify_out_path, 'sto',
+        self.use_precomputed_msas)
+
+    mgnify_msa = parsers.parse_stockholm(jackhmmer_mgnify_result['sto'])
+    mgnify_msa = mgnify_msa.truncate(max_seqs=self.mgnify_max_hits)
+    return mgnify_msa
+
+  def hhblits_bfd_uniclust_caller(self, input_fasta_path, msa_output_dir):
+    bfd_out_path = os.path.join(msa_output_dir, 'bfd_uniref_hits.a3m')
+    hhblits_bfd_uniref_result = run_msa_tool(
+        msa_runner=self.hhblits_bfd_uniref_runner,
+        input_fasta_path=input_fasta_path,
+        msa_out_path=bfd_out_path,
+        msa_format='a3m',
+        use_precomputed_msas=self.use_precomputed_msas)
+    bfd_msa = parsers.parse_a3m(hhblits_bfd_uniref_result['a3m'])
+    return bfd_msa
+
+  def jackhmmer_small_bfd_caller(self, input_fasta_path, msa_output_dir):
+    bfd_out_path = os.path.join(msa_output_dir, 'small_bfd_hits.sto')
+    jackhmmer_small_bfd_result = run_msa_tool(
+        msa_runner=self.jackhmmer_small_bfd_runner,
+        input_fasta_path=input_fasta_path,
+        msa_out_path=bfd_out_path,
+        msa_format='sto',
+        use_precomputed_msas=self.use_precomputed_msas)
+    bfd_msa = parsers.parse_stockholm(jackhmmer_small_bfd_result['sto'])
+    return bfd_msa
+
+
+  def process(self, input_fasta_path: str, msa_output_dir: str) -> FeatureDict:
+    """Runs alignment tools on the input sequence and creates features."""
+    with open(input_fasta_path) as f:
+      input_fasta_str = f.read()
+    input_seqs, input_descs = parsers.parse_fasta(input_fasta_str)
+    if len(input_seqs) != 1:
+      raise ValueError(
+          f'More than one input sequence found in {input_fasta_path}.')
+    input_sequence = input_seqs[0]
+    input_description = input_descs[0]
+    num_res = len(input_sequence)
+
+
+    futures = []
     if self._use_small_bfd:
-      bfd_out_path = os.path.join(msa_output_dir, 'small_bfd_hits.sto')
-      jackhmmer_small_bfd_result = run_msa_tool(
-          msa_runner=self.jackhmmer_small_bfd_runner,
-          input_fasta_path=input_fasta_path,
-          msa_out_path=bfd_out_path,
-          msa_format='sto',
-          use_precomputed_msas=self.use_precomputed_msas)
-      bfd_msa = parsers.parse_stockholm(jackhmmer_small_bfd_result['sto'])
+      with concurrent.futures.ThreadPoolExecutor(max_workers=self.n_parallel_msa) as executor:
+        futures.append(executor.submit(self.jackhmmer_uniref90_and_pdb_templates_caller, input_fasta_path, msa_output_dir, input_sequence))
+        futures.append(executor.submit(self.jackhmmer_mgnify_caller, input_fasta_path, msa_output_dir))
+        futures.append(executor.submit(self.jackhmmer_small_bfd_caller, input_fasta_path, msa_output_dir))
     else:
-      bfd_out_path = os.path.join(msa_output_dir, 'bfd_uniref_hits.a3m')
-      hhblits_bfd_uniref_result = run_msa_tool(
-          msa_runner=self.hhblits_bfd_uniref_runner,
-          input_fasta_path=input_fasta_path,
-          msa_out_path=bfd_out_path,
-          msa_format='a3m',
-          use_precomputed_msas=self.use_precomputed_msas)
-      bfd_msa = parsers.parse_a3m(hhblits_bfd_uniref_result['a3m'])
+       with concurrent.futures.ThreadPoolExecutor(max_workers=self.n_parallel_msa) as executor:
+        futures.append(executor.submit(self.jackhmmer_uniref90_and_pdb_templates_caller, input_fasta_path, msa_output_dir, input_sequence))
+        futures.append(executor.submit(self.jackhmmer_mgnify_caller, input_fasta_path, msa_output_dir))
+        futures.append(executor.submit(self.hhblits_bfd_uniclust_caller, input_fasta_path, msa_output_dir))
+
+    uniref90_msa, pdb_template_hits = futures[0].result()
+    mgnify_msa = futures[1].result()
+    bfd_msa = futures[2].result()
 
     templates_result = self.template_featurizer.get_templates(
         query_sequence=input_sequence,

--- a/alphafold/data/pipeline.py
+++ b/alphafold/data/pipeline.py
@@ -200,7 +200,7 @@ class DataPipeline:
     mgnify_msa = parsers.parse_stockholm(jackhmmer_mgnify_result['sto'])
     return mgnify_msa
 
-  def hhblits_bfd_uniclust_caller(self, input_fasta_path, msa_output_dir):
+  def hhblits_bfd_uniref_caller(self, input_fasta_path, msa_output_dir):
     bfd_out_path = os.path.join(msa_output_dir, 'bfd_uniref_hits.a3m')
     hhblits_bfd_uniref_result = run_msa_tool(
         msa_runner=self.hhblits_bfd_uniref_runner,
@@ -246,7 +246,7 @@ class DataPipeline:
       with concurrent.futures.ThreadPoolExecutor(max_workers=self.n_parallel_msa) as executor:
         futures.append(executor.submit(self.jackhmmer_uniref90_and_pdb_templates_caller, input_fasta_path, msa_output_dir, input_sequence))
         futures.append(executor.submit(self.jackhmmer_mgnify_caller, input_fasta_path, msa_output_dir))
-        futures.append(executor.submit(self.hhblits_bfd_uniclust_caller, input_fasta_path, msa_output_dir))
+        futures.append(executor.submit(self.hhblits_bfd_uniref_caller, input_fasta_path, msa_output_dir))
 
     uniref90_msa, pdb_template_hits = futures[0].result()
     mgnify_msa = futures[1].result()

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -142,6 +142,8 @@ flags.DEFINE_boolean('use_gpu_relax', None, 'Whether to relax on GPU. '
                      'recommended to enable if possible. GPUs must be available'
                      ' if this setting is enabled.')
 
+flags.DEFINE_integer('n_parallel_msa', 1, 'Number of parallel runs of MSA tools.')
+
 FLAGS = flags.FLAGS
 
 MAX_TEMPLATE_HITS = 20
@@ -394,7 +396,8 @@ def main(argv):
       template_searcher=template_searcher,
       template_featurizer=template_featurizer,
       use_small_bfd=use_small_bfd,
-      use_precomputed_msas=FLAGS.use_precomputed_msas)
+      use_precomputed_msas=FLAGS.use_precomputed_msas,
+      n_parallel_msa=FLAGS.n_parallel_msa)
 
   if run_multimer_system:
     num_predictions_per_model = FLAGS.num_multimer_predictions_per_model


### PR DESCRIPTION
Based on the dependencies among the data, the MSA tool execution is divided into the following three parts and the tools are called asynchronously to execute them in parallel.
- jackhmmer(uniref90) + template_searcher(pdb)
- jackhmmer(mgnify)
- hhblits(bfd) or jackhmmer(small_bfd)

Execution time may be reduced if sufficient cpu, memory and I/O performance are available.

The implementation uses `concurrent.futures.ThreadPoolExecutor` and `max_workers` can be specified with the `--n_parallel_msa` flag.
If `--n_parallel_msa` flag is 1, the execution is not parallelized.
The case where `--n_parallel_msa` flag is 3 is the maximum and potentially the fastest.

##### example
The following is a partial log of a T1041 run with 28 CPU cores and 235 GB of RAM.
```
I0222 13:49:16.924237 46912496428352 run_alphafold.py:165] Predicting T1041
I0222 13:49:16.927476 46924398855936 jackhmmer.py:133] Launching subprocess "/apps/t3/sles12sp4/free/alphafold/2.1.1/miniconda/py39_4.10.3/envs/alphafold/bin/jackhmmer -o /dev/null -A /scr/10806581.1.all.q/tmpcxmfcp42/output.sto --noali --F1 0.0005 --F2 5e-05 --F3 5e-07 --incE 0.0001 -E 0.0001 --cpu 8 -N 1 /home/4/18B13254/workspace/research/alphafold2-profiling/fasta/T1041.fasta /gs/hs0/GSIC/alphafold/2.1.1/data/uniref90/uniref90.fasta"
I0222 13:49:16.927617 46924403058432 hhblits.py:128] Launching subprocess "/home/4/18B13254/workspace/research/hh-suite/mirror/hh-suite/build-stable/bin/hhblits -i /home/4/18B13254/workspace/research/alphafold2-profiling/fasta/T1041.fasta -cpu 28 -oa3m /scr/10806581.1.all.q/tmpmd_hpnsn/output.a3m -o /dev/null -n 3 -e 0.001 -maxseq 1000000 -realign_max 100000 -maxfilt 100000 -min_prefilter_hits 1000 -d /gs/hs0/GSIC/alphafold/2.1.1/data/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt -d /gs/hs0/GSIC/alphafold/2.1.1/data/uniclust30/uniclust30_2018_08/uniclust30_2018_08"
I0222 13:49:16.927811 46924400957184 jackhmmer.py:133] Launching subprocess "/apps/t3/sles12sp4/free/alphafold/2.1.1/miniconda/py39_4.10.3/envs/alphafold/bin/jackhmmer -o /dev/null -A /scr/10806581.1.all.q/tmp36tcl19r/output.sto --noali --F1 0.0005 --F2 5e-05 --F3 5e-07 --incE 0.0001 -E 0.0001 --cpu 8 -N 1 /home/4/18B13254/workspace/research/alphafold2-profiling/fasta/T1041.fasta /gs/hs0/GSIC/alphafold/2.1.1/data/mgnify/mgy_clusters_2018_12.fa"
I0222 13:49:16.984938 46924398855936 utils.py:36] Started Jackhmmer (uniref90.fasta) query
I0222 13:49:17.004662 46924400957184 utils.py:36] Started Jackhmmer (mgy_clusters_2018_12.fa) query
I0222 13:49:17.071144 46924403058432 utils.py:36] Started HHblits query
I0222 13:55:33.821986 46924398855936 utils.py:40] Finished Jackhmmer (uniref90.fasta) query in 376.837 seconds
I0222 13:55:33.826219 46924398855936 hhsearch.py:85] Launching subprocess "/apps/t3/sles12sp4/free/alphafold/2.1.1/miniconda/py39_4.10.3/envs/alphafold/bin/hhsearch -i /scr/10806581.1.all.q/tmp_wlgfvtm/query.a3m -o /scr/10806581.1.all.q/tmp_wlgfvtm/output.hhr -maxseq 1000000 -d /gs/hs0/GSIC/alphafold/2.1.1/data/pdb70/pdb70"
I0222 13:55:33.920660 46924398855936 utils.py:36] Started HHsearch query
I0222 13:55:55.552874 46924403058432 utils.py:40] Finished HHblits query in 398.481 seconds
I0222 13:56:22.036781 46924400957184 utils.py:40] Finished Jackhmmer (mgy_clusters_2018_12.fa) query in 425.032 seconds
I0222 14:04:08.089480 46924398855936 utils.py:40] Finished HHsearch query in 514.168 seconds
```