### PR TITLE
Fix: GPG error - updating GPG key for CUDA repos

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,10 @@ ARG CUDA
 # Use bash to support string substitution.
 SHELL ["/bin/bash", "-c"]
 
+# update the GPG signing key for the CUDA repositories. NVIDIA updated on Apr 29
+# https://forums.developer.nvidia.com/t/the-repository-https-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64-release-is-not-signed/193764/9
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       build-essential \
       cmake \


### PR DESCRIPTION
NVIDIA has rotated its GPG key on April 29th. Currently NVIDIA is ["in the process of updating the Docker images and Dockerfiles, but doesn’t have an ETA at hand for any specific container image"](https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/8), so this may be a temporary fix.

However, without this apt-get update doesn't work, and neither is there any way to get the [CUDA related repos](https://forums.developer.nvidia.com/t/the-repository-https-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64-release-is-not-signed/193764/9).