### PR TITLE
Corrected relative gunzip small_bfd path

### DIFF
--- a/scripts/download_small_bfd.sh
+++ b/scripts/download_small_bfd.sh
@@ -37,5 +37,5 @@ BASENAME=$(basename "${SOURCE_URL}")
 mkdir --parents "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
 pushd "${ROOT_DIR}"
-gunzip "${ROOT_DIR}/${BASENAME}"
+gunzip "${BASENAME}"
 popd


### PR DESCRIPTION
The path used for gunzipping `small_bfd` in `scripts/download_small_bfd.sh` had a double reference to ROOT_DIR (i.e. `$ROOT_DIR/$ROOT_DIR/$BASENAME`), making gunzip unable to locate the gzip file.