### PR TITLE
Bundle all scripts and runtime virtual env.

### DIFF
--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -1,3 +1,5 @@
+#!/bin/env python
+
 # Copyright 2021 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 
 from setuptools import find_packages
 from setuptools import setup
+from glob import glob
 
 setup(
     name='alphafold',
@@ -27,6 +28,7 @@ setup(
     license='Apache License, Version 2.0',
     url='https://github.com/deepmind/alphafold',
     packages=find_packages(),
+    scripts=['run_alphafold.py'] + glob('scripts/*.sh'),
     install_requires=[
         'absl-py',
         'biopython',


### PR DESCRIPTION
Support running from a virtual env. as a script. Include run_alphafold.py and download scripts as well.

Bundle all scripts inside a wheel. This ease distribution and lets a user install the wheel inside his virtual environment. 
