### PR TITLE
reduce docker image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,18 +19,21 @@ FROM nvidia/cuda:${CUDA}-cudnn8-runtime-ubuntu18.04
 ARG CUDA
 
 # Use bash to support string substitution.
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         build-essential \
         cmake \
-        cuda-command-line-tools-$(cut -f1,2 -d- <<< ${CUDA//./-}) \
+        cuda-command-line-tools-"$(cut -f1,2 -d- <<< ${CUDA//./-})" \
         git \
         hmmer \
         kalign \
         tzdata \
         wget \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoremove -y \
+    && apt-get clean
 
 # Compile HHsuite from source.
 RUN git clone --branch v3.3.0 https://github.com/soedinglab/hh-suite.git /tmp/hh-suite \
@@ -44,7 +47,7 @@ RUN git clone --branch v3.3.0 https://github.com/soedinglab/hh-suite.git /tmp/hh
 
 # Install Miniconda package manager.
 RUN wget -q -P /tmp \
-  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+  "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" \
     && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
@@ -53,29 +56,29 @@ ENV PATH="/opt/conda/bin:$PATH"
 RUN conda update -qy conda \
     && conda install -y -c conda-forge \
       openmm=7.5.1 \
-      cudatoolkit==${CUDA_VERSION} \
+      cudatoolkit=="${CUDA_VERSION}" \
       pdbfixer \
       pip \
-      python=3.7
+      python=3.7 \
+    && conda clean -afy
 
 COPY . /app/alphafold
 RUN wget -q -P /app/alphafold/alphafold/common/ \
-  https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
+    "https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt"
 
 # Install pip packages.
-RUN pip3 install --upgrade pip \
-    && pip3 install -r /app/alphafold/requirements.txt \
-    && pip3 install --upgrade \
+RUN pip3 install --upgrade pip --no-cache-dir \
+    && pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
+    && pip3 install --upgrade --no-cache-dir \
       jax==0.2.14 \
-      jaxlib==0.1.69+cuda$(cut -f1,2 -d. <<< ${CUDA} | sed 's/\.//g') \
+      jaxlib==0.1.69+cuda"$(cut -f1,2 -d. <<< ${CUDA} | sed 's/\.//g')" \
       -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # Apply OpenMM patch.
 WORKDIR /opt/conda/lib/python3.7/site-packages
-RUN patch -p0 < /app/alphafold/docker/openmm.patch
-
-# Add SETUID bit to the ldconfig binary so that non-root users can run it.
-RUN chmod u+s /sbin/ldconfig.real
+RUN patch -p0 < /app/alphafold/docker/openmm.patch \
+    # Add SETUID bit to the ldconfig binary so that non-root users can run it.
+    && chmod u+s /sbin/ldconfig.real
 
 # We need to run `ldconfig` first to ensure GPUs are visible, due to some quirk
 # with Debian. See https://github.com/NVIDIA/nvidia-docker/issues/1399 for


### PR DESCRIPTION
PR reduces docker image size—a summary of the changes


* Adds `pipefail` to the `SHELL` directive for safety
* Added `--no-install-recommends` to `apt` and `autoremove`+`clean` as per [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) 
* Adds `conda clean -afy` to remove cache files, package tarballs, and the entire package cache. To ensure only necessary files are saved in each layer. [Ref](https://jcristharif.com/conda-docker-tips.html)
* Added `--no-cache-dir` to the `pip` installs since the pip cache isn't needed for a docker image
* Merged the two consecutive `RUN` directives into one
* Added quotes around various strings to ensure splitting doesn't occur

Followed rules from [hadolint](https://github.com/hadolint/hadolint) and [shellcheck](https://github.com/koalaman/shellcheck)

Running `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f docker/Dockerfile -t alphafold . --no-cache` (note the `DOCKER_DEFAULT_PLATFORM=linux/amd64` is used because I'm on a M1 MacBook) for the existing `Dockerfile`, and and the updated one (with the tag `alphafold-new `) here's the difference in size after the changes (`9.77GB` vs `12.5GB`)

```bash
$ docker images | grep alphafold
alphafold-new                                                                latest                              e823bb581ba2   12 minutes ago   9.77GB
alphafold                                                                    latest                              7ecff97027f2   45 minutes ago   12.5GB
```
