### PR TITLE
Fixing zip command issue in Google Colab.

### DIFF
--- a/notebooks/AlphaFold.ipynb
+++ b/notebooks/AlphaFold.ipynb
@@ -77,6 +77,7 @@
         "from IPython.utils import io\n",
         "import os\n",
         "import subprocess\n",
+        "import shutil\n",
         "import tqdm.notebook\n",
         "\n",
         "TQDM_BAR_FORMAT = '{l_bar}{bar}| {n_fmt}/{total_fmt} [elapsed: {elapsed} remaining: {remaining}]'\n",
@@ -765,7 +766,7 @@
         "    f.write(pae_data)\n",
         "\n",
         "# --- Download the predictions ---\n",
-        "!zip -q -r {output_dir}.zip {output_dir}\n",
+        "shutil.make_archive(output_dir, 'zip', output_dir)\n",
         "files.download(f'{output_dir}.zip')"
       ]
     },


### PR DESCRIPTION
When running the Google Colab notebook implementation cell `5. Run AlphaFold and download prediction` is throwing the following error:

```
NotImplementedError                       Traceback (most recent call last)
[<ipython-input-1-bc0091fa34e2>](https://localhost:8080/#) in <module>()
    577 sequence = 'AKIGLFYGTQTGVTQTIAESIQQEFGGESIVDLNDIANADASDLNAYDYLIIGCPTWNVGELQSDWEGIYDDLDSVNFQGKKVAYFGAGDQVGYSDNFQDAMGILEEKISSLGSQTVGYWPIEGYDFNESKAVRNNQFVGLAIDEDNQPDLTKNRIKTWVSQLKSEFGL'  #@param {type:"string"}
    578 
--> 579 run_prediction(sequence)

3 frames
[/usr/local/lib/python3.7/dist-packages/google/colab/_system_commands.py](https://localhost:8080/#) in _run_command(cmd, clear_streamed_output)
    166   if locale_encoding != _ENCODING:
    167     raise NotImplementedError(
--> 168         'A UTF-8 locale is required. Got {}'.format(locale_encoding))
    169 
    170   parent_pty, child_pty = pty.openpty()

NotImplementedError: A UTF-8 locale is required. Got ANSI_X3.4-1968
```
As discussed in the issue: https://github.com/deepmind/alphafold/issues/483 

This is more of a Google Colab issue when trying to create the`output_dir ` zip file from the`output_dir ` folder. I solved this by using`shutil ` to create the zip file.

I simply replace the line of code `!zip -q -r {output_dir}.zip {output_dir} ` from cell `5. Run AlphaFold and download prediction` with `shutil.make_archive(output_dir, 'zip', output_dir)`
I also made sure to add `import shutil` at the first cell.

This will create the zip file without using any terminal commands. This fix should not cause any issues in the future since we don't rely on the Google Colab terminal commands anymore.
