### PR TITLE
Clarify explanation of `ranked_*.pdb` output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,12 +576,13 @@ The contents of each output file are as follows:
     structure, after performing an Amber relaxation procedure on the unrelaxed
     structure prediction (see Jumper et al. 2021, Suppl. Methods 1.8.6 for
     details).
-*   `ranked_*.pdb` – A PDB format text file containing the relaxed predicted
-    structures, after reordering by model confidence. Here `ranked_0.pdb` should
-    contain the prediction with the highest confidence, and `ranked_4.pdb` the
-    prediction with the lowest confidence. To rank model confidence, we use
+*   `ranked_*.pdb` – A PDB format text file containing the predicted structures,
+    after reordering by model confidence. Here `ranked_i.pdb` should contain
+    the prediction with the (`i + 1`)-th highest confidence (so that
+    `ranked_0.pdb` has the highest confidence). To rank model confidence, we use
     predicted LDDT (pLDDT) scores (see Jumper et al. 2021, Suppl. Methods 1.9.6
-    for details).
+    for details). Depending on the value of `--models_to_relax`, only one
+    (`ranked_0.pdb`), all, or none of these structures are relaxed.
 *   `ranking_debug.json` – A JSON format text file containing the pLDDT values
     used to perform the model ranking, and a mapping back to the original model
     names.


### PR DESCRIPTION
It seems to me that a couple of small things are off in the explanation of the `ranked_*.pdb` output files in the readme, particularly since v2.3.1.

First, there may be more than 5 predicted models (default is in fact 25? Or so I see in my outputs when using default parameters) so `ranked_4.pdb` may not be the model with lowest confidence.

Secondly, some models may be unrelaxed (even all of them may be unrelaxed), so characterizing these files as being all "relaxed predicted structures" seems problematic.

Here is a suggestion, but I'm happy for the precise wording to be changed as needed.