### PR TITLE
Updated cuda base image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please follow these steps:
 1.  Check that AlphaFold will be able to use a GPU by running:
 
     ```bash
-    docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
+    docker run --rm --gpus all nvidia/cuda:11.0.3-base nvidia-smi
     ```
 
     The output of this command should show a list of your GPUs. If it doesn't,


### PR DESCRIPTION
```
docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
```
does not work any more but:

```
docker run --rm --gpus all nvidia/cuda:11.0.3-base nvidia-smi
```
is