### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Environments
+*.venv/
+*.venv.bak/
+
+# VSCode
+.vscode/
+*.code-workspace


### PR DESCRIPTION
Taken from https://github.com/github/gitignore. I didn't include everything: just things I think of as commonly used tools. venvs are explicitly called out in the README and vscode is a very common editor (it's what I'm using). Happy to drop the packaging stuff or otherwise make it more targeted.