### PR TITLE
Remove stale haiku version check in sharded_map

### DIFF
--- a/alphafold/model/mapping.py
+++ b/alphafold/model/mapping.py
@@ -15,7 +15,6 @@
 """Specialized mapping functions."""
 
 import functools
-import inspect
 from typing import Any, Callable, Optional, Sequence, TypeVar, Union
 
 import haiku as hk
@@ -90,11 +89,7 @@ def sharded_map(
   Returns:
     function with smap applied.
   """
-  if 'split_rng' in inspect.signature(hk.vmap).parameters:
-    vmapped_fun = hk.vmap(fun, in_axes, out_axes, split_rng=False)
-  else:
-    # TODO(tomhennigan): Remove this when older versions of Haiku aren't used.
-    vmapped_fun = hk.vmap(fun, in_axes, out_axes)
+  vmapped_fun = hk.vmap(fun, in_axes, out_axes, split_rng=False)
   return sharded_apply(vmapped_fun, shard_size, in_axes, out_axes)
 
 


### PR DESCRIPTION
### Summary
This PR removes dead code in [sharded_map()](cci:1://file:///c:/Users/tiwar/.gemini/antigravity/scratch/alphafold/alphafold/model/mapping.py:69:0-97:66) that checks for the `split_rng` parameter in older Haiku versions.

### Motivation
The [sharded_map](cci:1://file:///c:/Users/tiwar/.gemini/antigravity/scratch/alphafold/alphafold/model/mapping.py:69:0-97:66) function in [alphafold/model/mapping.py](cci:7://file:///c:/Users/tiwar/.gemini/antigravity/scratch/alphafold/alphafold/model/mapping.py:0:0-0:0) previously included a runtime check to determine whether `hk.vmap` supports the `split_rng` parameter. Since [pyproject.toml](cci:7://file:///c:/Users/tiwar/.gemini/antigravity/scratch/alphafold/pyproject.toml:0:0-0:0) pins `dm-haiku==0.0.12` and this version includes the `split_rng` parameter, the else branch is unreachable dead code.

This resolves the TODO(tomhennigan) comment asking to remove this code when older versions of Haiku aren't used.

### Changes
- Removed the runtime version check using `inspect.signature`
- Removed the unused `inspect` import
- Simplified [sharded_map](cci:1://file:///c:/Users/tiwar/.gemini/antigravity/scratch/alphafold/alphafold/model/mapping.py:69:0-97:66) to directly call `hk.vmap(..., split_rng=False)`

### Testing
- Verified syntax correctness with `python -m py_compile`
- No functional changes - the if-branch was always taken with the pinned Haiku version