### PR TITLE
Use os.devnull instead of hardcoded /dev/null

### DIFF
--- a/alphafold/data/tools/hhblits.py
+++ b/alphafold/data/tools/hhblits.py
@@ -111,7 +111,7 @@ class HHBlits:
           *('-i', input_fasta_path),
           *('-cpu', str(self.n_cpu)),
           *('-oa3m', a3m_path),
-          *('-o', '/dev/null'),
+          *('-o', os.devnull),
           *('-n', str(self.n_iter)),
           *('-e', str(self.e_value)),
           *('-maxseq', str(self.maxseq)),

--- a/alphafold/data/tools/jackhmmer.py
+++ b/alphafold/data/tools/jackhmmer.py
@@ -106,7 +106,7 @@ class Jackhmmer:
       # amount of time.
       cmd_flags = [
           # Don't pollute stdout with Jackhmmer output.
-          *('-o', '/dev/null'),
+          *('-o', os.devnull),
           *('-A', sto_path),
           '--noali',
           *('--F1', str(self.filter_f1)),


### PR DESCRIPTION
Replace hardcoded Unix path '/dev/null' with Python's cross-platform os.devnull constant in jackhmmer.py and hhblits.py.

This follows Python best practices and improves code portability, though functionally equivalent on Linux.