### PR TITLE
Fix missing return and pytype issue in will_restrain

### DIFF
--- a/alphafold/relax/amber_minimize.py
+++ b/alphafold/relax/amber_minimize.py
@@ -43,7 +43,12 @@ def will_restrain(atom: openmm_app.Atom, rset: str) -> bool:
   if rset == "non_hydrogen":
     return atom.element.name != "hydrogen"
   elif rset == "c_alpha":
-    return atom.name == "CA"  # pytype: disable=bad-return-type
+    return bool(atom.name == "CA")
+  else:
+    raise ValueError(
+        f'Unknown restraint set: "{rset}". '
+        'Expected "non_hydrogen" or "c_alpha".'
+    )
 
 
 def _add_restraints(


### PR DESCRIPTION
The will_restrain function previously had two issues: no explicit return/raise for invalid rset values (would return None), and a pytype: disable comment to suppress a type checking error.

This commit adds an else clause that raises ValueError with a descriptive message for invalid rset values, and replaces the pytype suppression with an explicit bool() conversion.