### PR TITLE
updated requirements for newer Docker versions and updated Jax synthax

### DIFF
--- a/alphafold/common/confidence.py
+++ b/alphafold/common/confidence.py
@@ -17,7 +17,7 @@
 import json
 from typing import Dict, Optional, Tuple
 
-from jax.scipy import special
+import jax.nn as nn
 import numpy as np
 
 
@@ -33,7 +33,7 @@ def compute_plddt(logits: np.ndarray) -> np.ndarray:
   num_bins = logits.shape[-1]
   bin_width = 1.0 / num_bins
   bin_centers = np.arange(start=0.5 * bin_width, stop=1.0, step=bin_width)
-  probs = np.array(special.softmax(logits, axis=-1))
+  probs = np.array(nn.softmax(logits, axis=-1))
   predicted_lddt_ca = np.sum(probs * bin_centers[None, :], axis=-1)
   return predicted_lddt_ca * 100
 
@@ -135,7 +135,7 @@ def compute_predicted_aligned_error(
       error for each pair of residues.
     max_predicted_aligned_error: The maximum predicted error possible.
   """
-  aligned_confidence_probs = np.array(special.softmax(logits, axis=-1))
+  aligned_confidence_probs = np.array(nn.softmax(logits, axis=-1))
   predicted_aligned_error, max_predicted_aligned_error = (
       _calculate_expected_aligned_error(
           alignment_confidence_breaks=breaks,
@@ -215,7 +215,7 @@ def predicted_tm_score(
   d0 = 1.24 * (clipped_num_res - 15) ** (1.0 / 3) - 1.8
 
   # Convert logits to probs.
-  probs = np.array(special.softmax(logits, axis=-1))
+  probs = np.array(nn.softmax(logits, axis=-1))
 
   # TM-Score term for every bin.
   tm_per_bin = 1.0 / (1 + np.square(bin_centers) / np.square(d0))

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,3 +1,3 @@
 # Dependencies necessary to execute run_docker.py
 absl-py==1.0.0
-docker==5.0.0
+docker==7.1.0


### PR DESCRIPTION
I ran into an issue, that the run_docker.py file could not connect to a running docker instance, which was solved by updating the docker version in docker/requirements.txt
I also ran into the Error: "AttributeError: module 'jax.scipy.special' has no attribute 'softmax'" in alphafold/common/confidence.py this was fixed by updating the import syntax. 