### PR TITLE
Fix unhandled exceptions in MSA parsing and PDB serialization

### DIFF
--- a/alphafold/common/protein.py
+++ b/alphafold/common/protein.py
@@ -297,7 +297,8 @@ def to_pdb(prot: Protein) -> str:
       charge = ''
       # PDB is a columnar format, every space matters here!
       atom_line = (
-          f'{record_type:<6}{atom_index:>5} {name:<4}{alt_loc:>1}'
+          display_index = atom_index % 100000
+          f'{record_type:<6}{display_index:>5} {name:<4}{alt_loc:>1}'
           f'{res_name_3:>3} {chain_ids[chain_index[i]]:>1}'
           f'{residue_index[i]:>4}{insertion_code:>1}   '
           f'{pos[0]:>8.3f}{pos[1]:>8.3f}{pos[2]:>8.3f}'

--- a/alphafold/data/parsers.py
+++ b/alphafold/data/parsers.py
@@ -140,6 +140,11 @@ def parse_stockholm(stockholm_string: str) -> Msa:
       keep_columns = [i for i, res in enumerate(query) if res != '-']
 
     # Remove the columns with gaps in the query from all sequences.
+    if keep_columns and len(sequence) <= max(keep_columns):
+      raise ValueError(
+          f'Malformed MSA: Hit sequence length ({len(sequence)}) is strictly '
+          f'shorter than required columns ({max(keep_columns)}).'
+      )
     aligned_sequence = ''.join([sequence[c] for c in keep_columns])
 
     msa.append(aligned_sequence)


### PR DESCRIPTION
### Description
This PR addresses two edge-case logic flaws that can cause the pipeline to crash completely due to unhandled exceptions during data processing.

1. **MSA Parsing OOB Access:** In `alphafold/data/parsers.py`, if a provided MSA contains a truncated sequence hit that is shorter than the query's active columns, the list comprehension throws an unhandled `IndexError`. Added a length boundary check to raise a descriptive `ValueError`.
2. **PDB Serialization Column Shift:** In `alphafold/common/protein.py`, if an excessively large sequence is processed, the Python formatter `{:>5}` dynamically expands to 6 characters. This breaks the strict fixed-width PDB format, causing OpenMM to fail with `ValueError`. Added a modulo truncation (`% 100000`) to strictly enforce PDB column boundaries.

These fixes improve the robustness of the pipeline when processing large or manually crafted datasets.