### PR TITLE
docs: clarify updating an existing AlphaFold checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,15 @@ update that will be significantly faster but will require a bit more work. Make
 sure you follow these steps in the exact order they are listed below:
 
 1.  **Update the code.**
-    *   Go to the directory with the cloned AlphaFold repository and run `git
-        fetch origin main` to get all code updates.
+    *   Go to the directory with the cloned AlphaFold repository and run:
+
+        ```bash
+        git checkout main
+        git pull --ff-only origin main
+        ```
+
+        This updates the local checkout to the latest `main` branch without
+        creating a merge commit.
 1.  **Update the UniProt, UniRef, MGnify and PDB seqres databases.**
     *   Remove `<DOWNLOAD_DIR>/uniprot`.
     *   Run `scripts/download_uniprot.sh <DOWNLOAD_DIR>`.


### PR DESCRIPTION
Fixes #654.

The update instructions currently mention `git fetch origin main`, but `git fetch` only downloads updates and does not update the working tree.

Use `git checkout main` followed by `git pull --ff-only origin main` so users explicitly update their local checkout without creating a merge commit.

I did not find an open linked PR for this issue.

Validation:
- git diff --check

Not performed:
- AlphaFold runtime test
- Docker build
- GPU/CUDA validation
- Database download