### PR TITLE
docker: update Python Docker SDK dependency

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,3 +1,3 @@
 # Dependencies necessary to execute run_docker.py
 absl-py==1.0.0
-docker==5.0.0
+docker==7.1.0


### PR DESCRIPTION
Fixes #1066.

Hi, `docker/run_docker.py` depends on the Python Docker SDK, but `docker/requirements.txt` still pins `docker==5.0.0`. Newer Docker/Python dependency stacks can fail before the container starts with errors such as an unsupported `http+docker` URL scheme. As seen in #1066.

This PR updates the Python Docker SDK dependency to `docker==7.1.0`. The launcher still imports successfully with this version and the Docker SDK types used by `run_docker.py` remain available.

Validation:
- `git diff --check`
- temporary venv: `python -m pip install -r docker/requirements.txt`
- `python -m py_compile docker/run_docker.py`
- verified `docker==7.1.0` exposes `docker.types.Mount` and `docker.types.DeviceRequest`

Not performed:
- Docker container run
- AlphaFold runtime test
- GPU/CUDA validation