### PR TITLE
docker: expose MSA CPU flags

### DIFF
--- a/docker/run_docker.py
+++ b/docker/run_docker.py
@@ -116,6 +116,27 @@ flags.DEFINE_boolean(
     'WARNING: This will not check if the sequence, database or configuration '
     'have changed.',
 )
+flags.DEFINE_integer(
+    'jackhmmer_n_cpu',
+    None,
+    'Number of CPUs to use for Jackhmmer. If unset, run_alphafold.py uses its '
+    'default.',
+    lower_bound=0,
+)
+flags.DEFINE_integer(
+    'hmmsearch_n_cpu',
+    None,
+    'Number of CPUs to use for HMMsearch. If unset, run_alphafold.py uses its '
+    'default.',
+    lower_bound=0,
+)
+flags.DEFINE_integer(
+    'hhsearch_n_cpu',
+    None,
+    'Number of CPUs to use for HHsearch. If unset, run_alphafold.py uses its '
+    'default.',
+    lower_bound=0,
+)
 flags.DEFINE_string(
     'docker_user',
     f'{os.geteuid()}:{os.getegid()}',
@@ -275,6 +296,13 @@ def main(argv):
       f'--use_gpu_relax={use_gpu_relax}',
       '--logtostderr',
   ])
+
+  if FLAGS.jackhmmer_n_cpu is not None:
+    command_args.append(f'--jackhmmer_n_cpu={FLAGS.jackhmmer_n_cpu}')
+  if FLAGS.hmmsearch_n_cpu is not None:
+    command_args.append(f'--hmmsearch_n_cpu={FLAGS.hmmsearch_n_cpu}')
+  if FLAGS.hhsearch_n_cpu is not None:
+    command_args.append(f'--hhsearch_n_cpu={FLAGS.hhsearch_n_cpu}')
 
   client = docker.from_env()
   device_requests = (


### PR DESCRIPTION
Fixes #801.

`run_alphafold.py` already supports `--jackhmmer_n_cpu`, `--hmmsearch_n_cpu`, and `--hhsearch_n_cpu`, but `docker/run_docker.py` does not expose or forward those options.

Add optional pass-through flags to the Docker launcher. When the flags are unset, no extra arguments are added and `run_alphafold.py` keeps using its existing defaults.

Validation:
- `git diff --check`
- `python -m py_compile docker/run_docker.py`
- temporary venv: `python -m pip install -r docker/requirements.txt`
- generated `python docker/run_docker.py --helpshort` output and verified the new flags are listed

Not performed:
- Docker container run
- AlphaFold runtime test
- GPU/CUDA validation